### PR TITLE
feat: add transition duration prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ myChart
 | <b>zoomReset</b>() | Programmatically reset the zoom to the global view. | |
 | <b>onHover</b>([<i>fn</i>]) | Callback function for mouse hover events. Includes the data node object (or `null` if hovering on background) as single argument. | |
 | <b>onClick</b>([<i>fn</i>]) | Callback function for click events. Includes the data node object (or `null` if clicking on the background) as single argument. A falsy value (default) automatically zooms on clicked nodes, equivalent to `myChart.onClick(myChart.zoomToNode)`. | |
+| <b>transitionDuration</b>([<i>number</i>]) | Getter/setter for the animation duration of transitions between states (opening, zoom in/out) in milliseconds. Enter 0 to disable animations. | `800` |
 
 ## Data syntax
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ myChart
 | <b>zoomReset</b>() | Programmatically reset the zoom to the global view. | |
 | <b>onHover</b>([<i>fn</i>]) | Callback function for mouse hover events. Includes the data node object (or `null` if hovering on background) as single argument. | |
 | <b>onClick</b>([<i>fn</i>]) | Callback function for click events. Includes the data node object (or `null` if clicking on the background) as single argument. A falsy value (default) automatically zooms on clicked nodes, equivalent to `myChart.onClick(myChart.zoomToNode)`. | |
-| <b>transitionDuration</b>([<i>number</i>]) | Getter/setter for the animation duration of transitions between states (opening, zoom in/out) in milliseconds. Enter 0 to disable animations. | `800` |
+| <b>transitionDuration</b>([<i>number</i>]) | Getter/setter for the animation duration of transitions between states (opening, zoom in/out) in milliseconds. Enter `0` to disable animations. | `800` |
 
 ## Data syntax
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -73,6 +73,9 @@ export interface TreemapChartGenericInstance<ChainableInstance> {
   zoomToNode(node: Node): ChainableInstance;
   zoomBy(k: number):ChainableInstance;
   zoomReset():ChainableInstance;
+
+  transitionDuration(): number;
+  transitionDuration(duration: number): ChainableInstance;
 }
 
 export type TreemapChartInstance = TreemapChartGenericInstance<TreemapChartInstance>;

--- a/src/treemap.js
+++ b/src/treemap.js
@@ -10,7 +10,6 @@ import accessorFn from 'accessor-fn';
 
 const LABELS_WIDTH_OPACITY_SCALE = scaleLinear().domain([4, 8]).clamp(true); // px per char
 const LABELS_HEIGHT_OPACITY_SCALE = scaleLinear().domain([6, 18]).clamp(true); // available height in px
-const TRANSITION_DURATION = 800;
 
 export default Kapsule({
 
@@ -35,15 +34,16 @@ export default Kapsule({
     tooltipTitle: { default: null, triggerUpdate: false },
     tooltipContent: { default: d => '', triggerUpdate: false },
     onClick: { triggerUpdate: false },
-    onHover: { triggerUpdate: false }
+    onHover: { triggerUpdate: false },
+    transitionDuration: { default: 800, triggerUpdate: false }
   },
   methods: {
     zoomBy: function(state, k) {
-      state.zoom.zoomBy(k, TRANSITION_DURATION);
+      state.zoom.zoomBy(k, state.transitionDuration);
       return this;
     },
     zoomReset: function(state) {
-      state.zoom.zoomReset(TRANSITION_DURATION);
+      state.zoom.zoomReset(state.transitionDuration);
       return this;
     },
     zoomToNode: function(state, d = {}) {
@@ -63,7 +63,7 @@ export default Kapsule({
           ))
         };
 
-        state.zoom.zoomTo(tr, TRANSITION_DURATION);
+        state.zoom.zoomTo(tr, state.transitionDuration);
       }
       return this;
     },
@@ -168,7 +168,7 @@ export default Kapsule({
 
     const animate = !state.skipTransitionsOnce;
     state.skipTransitionsOnce = false;
-    const transition = d3Transition().duration(animate ? TRANSITION_DURATION: 0);
+    const transition = d3Transition().duration(animate ? state.transitionDuration: 0);
 
     // Exiting
     cell.exit().transition(transition).remove();


### PR DESCRIPTION
This pull request adds a `transitionDuration` prop  to control animation duration of transitions between states (opening, zoom in/out).